### PR TITLE
feat: Slack通知のスレッド化対応およびvLLMプロセス終了処理の改善

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 
 def run_batch():
@@ -6,6 +7,7 @@ def run_batch():
     from fetch_papers import select_papers
     from summarize import summarize_papers_vllm
     from post_slack import post_papers_slack
+    from summarize import unload_model
 
     # 論文を取得
     selected_papers, survey_papers = select_papers(num_main=3, num_survey=1)
@@ -20,6 +22,9 @@ def run_batch():
 
     # Slackに投稿
     post_papers_slack(summarized_papers)
+    
+    unload_model()
+    sys.exit(0)
 
 
 def run_bot():

--- a/src/post_slack.py
+++ b/src/post_slack.py
@@ -1,38 +1,78 @@
 import os
-import requests
 import dotenv
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
 
-# .env または環境変数から取得
 dotenv.load_dotenv()
-SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
+SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN")
+SLACK_CHANNEL_ID = os.environ.get("SLACK_CHANNEL_ID")
 
-if not SLACK_WEBHOOK_URL:
-    raise ValueError("Slack Webhook URL が設定されていません。")
+if not SLACK_BOT_TOKEN or not SLACK_CHANNEL_ID:
+    raise ValueError("Slack Bot Token または Channel ID が設定されていません。")
 
+client = WebClient(token=SLACK_BOT_TOKEN)
 
 def post_papers_slack(papers):
     """
-    論文リストを Slack に投稿
-    Args:
-        papers (list[dict]): 各論文の slack_summary を含む辞書
+    論文リストを Slack に投稿（親メッセージに一覧、スレッドに要約）
+    親メッセージには各要約へのリンク [summary] を付与する
     """
-    blocks = []
-    for i, paper in enumerate(papers):
-        if "slack_summary" in paper:
-            blocks.append({
-                "type": "section",
-                # "text": {"type": "mrkdwn", "text": f"*論文番号{i+1}*\n{paper['slack_summary']}"}
-                "text": {"type": "mrkdwn", "text": f"{paper['slack_summary']}"}
-            })
-            blocks.append({"type": "divider"})  # 水平線
+    if not papers:
+        return
 
-    payload = {"blocks": blocks}
-    response = requests.post(SLACK_WEBHOOK_URL, json=payload)
+    try:
+        response = client.chat_postMessage(
+            channel=SLACK_CHANNEL_ID,
+            text=f"*本日の新着論文 ({len(papers)}件)*\nスレッドに要約を投稿しています...",
+            unfurl_links=False,
+            unfurl_media=False
+        )
+        thread_ts = response["ts"]
+        print("Slack 親メッセージ（仮）投稿成功")
 
-    print("投稿内容 (block 形式):")
-    for i in range(len(blocks)):
-        print(blocks[i])
-    if not response.ok:
-        print(f"Slack 投稿エラー: {response.status_code} {response.text}")
-    else:
-        print("Slack 投稿成功")
+        reply_links = []
+        for i, paper in enumerate(papers):
+            if "slack_summary" in paper:
+                blocks = [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": f"{paper['slack_summary']}"}
+                    }
+                ]
+                
+                if i < len(papers) - 1:
+                    blocks.append({"type": "divider"})
+                
+                reply_res = client.chat_postMessage(
+                    channel=SLACK_CHANNEL_ID,
+                    blocks=blocks,
+                    thread_ts=thread_ts,
+                    unfurl_links=False,
+                    unfurl_media=False
+                )
+                
+                permalink_res = client.chat_getPermalink(
+                    channel=SLACK_CHANNEL_ID, 
+                    message_ts=reply_res["ts"]
+                )
+                reply_links.append(permalink_res["permalink"])
+            else:
+                reply_links.append(None)
+                
+        print("Slack スレッドへの要約投稿成功")
+
+        main_text = f"*本日の新着論文 ({len(papers)}件)*\n\n"
+        for i, paper in enumerate(papers):
+            title = paper.get('title', f'論文 {i+1}')
+            summary_link = f" <{reply_links[i]}|[summary]>" if reply_links[i] else ""
+            main_text += f"•  {title}{summary_link}\n"
+            
+        client.chat_update(
+            channel=SLACK_CHANNEL_ID,
+            ts=thread_ts,
+            text=main_text
+        )
+        print("Slack 親メッセージの更新（リンク追加）成功")
+
+    except SlackApiError as e:
+        print(f"Slack 投稿エラー: {e.response['error']}")

--- a/src/summarize.py
+++ b/src/summarize.py
@@ -101,7 +101,7 @@ def summarize_paper_vllm(paper):
     summary_text = re.sub(r'(^|\n)[ \t]*-', r'\1• ', summary_text)
 
     # --- 5) Slack用に整形 ---
-    slack_text = f"*{title}* <{url}|[link]>\n\n{summary_text.strip()}\n\n"
+    slack_text = f"*{title}* <{url}|[arXiv]>\n\n{summary_text.strip()}\n\n"
     return slack_text
 
 


### PR DESCRIPTION
本PRでは, Slack通知の視認性向上を目的とした通知構造の刷新と, vLLMを使用した場合にバッチ処理が正常に終了しない問題の修正を行いました.

### 変更内容

- **Slack通知の改善 (`src/post_slack.py`)**
    - 従来の Incoming Webhook から Slack API (`slack_sdk`) を使用する方式に移行しました.
    - 通知形式を「親メッセージにタイトル一覧を投稿し, そのスレッドに各論文の要約をぶら下げる」形に変更しました.
    - 親メッセージの各論文タイトル横に, スレッド内の要約へ直接飛べる `[summary]` リンクを追加しました.
    - チャンネル汚染を防ぐため, リンクプレビュー (`unfurl_links`, `unfurl_media`) を一律で無効化しました. 
    - 要約間の区切りとして `divider` (水平線) を追加しました. 

- **バッチ処理の終了処理追加 (`src/main.py`)**
    - `run_batch()` の実行後に `sys.exit(0)` を追加しました. これにより, vLLMのバックグラウンドプロセス（GPUワーカー等）が残り続けて処理がハングする問題を解消しています. 

- **要約フォーマットの調整 (`src/summarize.py`)**
    - Slackに表示される元論文へのリンクテキストを `[link]` から `[arXiv]` に変更しました. 